### PR TITLE
Mitigate against malformed doi from orcid

### DIFF
--- a/_cite/plugins/orcid.py
+++ b/_cite/plugins/orcid.py
@@ -49,6 +49,11 @@ def main(entry):
         id_type = get_safe(_id, "external-id-type", "")
         id_value = get_safe(_id, "external-id-value", "")
 
+        # protect against malformed entries
+        if id_type == "doi" and id_value.startswith("https://doi.org/"):
+            log('Fix doi by removing "https://doi.org/"')
+            id_value = id_value.replace("https://doi.org/", "")
+
         # create source
         source = {"id": f"{id_type}:{id_value}"}
 


### PR DESCRIPTION
Sometimes it seems that the orcid endpoint returns malformed value for the doi type by returning a URL instead of a proper doi. 

This PR just checks if an id of type `doi` contains the string `"https://doi.org/"` and removes it if it does.

An example is the doi: `10.1145/3706599.3706731`
At that url: https://pub.orcid.org/v3.0/0000-0002-8364-0593/works

<img width="1204" height="103" alt="2025-09-02_14-26-47" src="https://github.com/user-attachments/assets/cb03b2bc-265c-4766-a924-0791ab109c35" />


